### PR TITLE
continuous tcpstats ondemand

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ docker run -p 8080:8080 [--name <container-name>] richimarchi/latency-tester_ser
 
 ```
 docker pull richimarchi/latency-tester_client
-docker run -p 8080:8080 [--name <container-name>] -v <local-log-folder>:/tmp richimarchi/latency-tester_client:latest [-reps=<repetitions>] [-requestPayload=<bytes>] [-responsePayload=<bytes>] [-interval=<ms>] [-tls=<enabled>] [-traceroute=<enabled>] [-log=<log-file>] <address> <ping-ip>
+docker run -p 8080:8080 [--name <container-name>] -v <local-log-folder>:/tmp richimarchi/latency-tester_client:latest [-reps=<repetitions>] [-requestPayload=<bytes>] [-responsePayload=<bytes>] [-interval=<ms>] [-tcpStats=<enabled>] [-tls=<enabled>] [-traceroute=<enabled>] [-log=<log-file>] <address> <ping-ip>
 ```
 
 #### Required input parameters
@@ -49,6 +49,7 @@ docker run -p 8080:8080 [--name <container-name>] -v <local-log-folder>:/tmp ric
 |`-requestPayload`|Request payload size (in bytes), minimum value: `62`|`64`|
 |`-responsePayload`|Response payload size (in bytes), minimum value: `62`|`64`|
 |`-interval`|Requests send interval (in milliseconds)|`1000`|
+|`-tcpStats`|`true` if TCP Stats requested (short execution time is suggested, as it consumes a lot of CPU and RAM)|`false`|
 |`-tls`|`true` if TLS requested|`false`|
 |`-traceroute`|`true` if traceroute is requested to run|`false`|
 |`-log`|Define the name of the file|`log`|

--- a/client/client.go
+++ b/client/client.go
@@ -17,8 +17,9 @@ var logFile = flag.String("log", "log", "file to store latency numbers")
 var requestBytes = flag.Uint64("requestPayload", 64, "bytes of the payload")
 var responseBytes = flag.Uint64("responsePayload", 64, "bytes of the response payload")
 var interval = flag.Uint64("interval", 1000, "send interval time (ms)")
-var https = flag.Bool("tls", false, "true if tls enabled")
+var https = flag.Bool("tls", false, "true if TLS enabled")
 var traceroute = flag.Bool("traceroute", false, "true if traceroute requested")
+var sockOpt = flag.Bool("tcpStats", false, "true if TCP Stats requested")
 var address string
 var pingIp string
 
@@ -62,15 +63,6 @@ func main() {
 	}
 	osRtt.WriteString("#timestamp,os-rtt\n")
 	defer osRtt.Close()
-	tcpStats, tcpStatsFileErr := os.Create(LogPath + "tcp-stats_" + *logFile + ".csv")
-	if tcpStatsFileErr != nil {
-		log.Fatalf("failed creating file: %s", tcpStatsFileErr)
-	}
-	tcpStats.WriteString("#timestamp,message-id,state,ca_state,retransmits,probes,backoff,options,pad_cgo_0-0," +
-		"pad_cgo_0-1,rto,ato,snd_mss,rcv_mss,unacked,sacked,lost,retrans,fackets,last_data_sent,last_ack_sent," +
-		"last_data_recv,last_ack_recv,pmtu,rcv_ssthresh,rtt,rttvar,snd_ssthresh,snd_cwnd,advmss,reordering,rcv_rtt," +
-		"rcv_space,total_retrans\n")
-	defer tcpStats.Close()
 
 	if *traceroute {
 		tracerouteFile, tracerouteFileErr := os.Create(LogPath + "traceroute_" + *logFile)
@@ -97,10 +89,21 @@ func main() {
 	ssReading := true
 	var msgId uint64 = 0
 
-	// Parallel os ping and tcp stats handlers
-	wg.Add(2)
+	// Parallel os ping and, if explicitly requested, tcp stats handlers
+	wg.Add(1)
 	go customPing(pingIp, &wg, donePing, osRtt)
-	go getSocketStats(conn, &ssReading, tcpStats, &wg, &msgId)
+	if *sockOpt {
+		tcpStats, tcpStatsFileErr := os.Create(LogPath + "tcp-stats_" + *logFile + ".csv")
+		if tcpStatsFileErr != nil {
+			log.Fatalf("failed creating file: %s", tcpStatsFileErr)
+		}
+		tcpStats.WriteString("#timestamp,message-id,state,ca_state,retransmits,probes,backoff,options,pad_cgo_0-0," +
+			"pad_cgo_0-1,rto,ato,snd_mss,rcv_mss,unacked,sacked,lost,retrans,fackets,last_data_sent,last_ack_sent," +
+			"last_data_recv,last_ack_recv,pmtu,rcv_ssthresh,rtt,rttvar,snd_ssthresh,snd_cwnd,advmss,reordering,rcv_rtt," +
+			"rcv_space,total_retrans\n")
+		wg.Add(1)
+		go getSocketStats(conn, &ssReading, tcpStats, &wg, &msgId, reset)
+	}
 
 	// Start making requests
 	requestSender(conn, interrupt, &ssReading, reset, &msgId)

--- a/client/client.go
+++ b/client/client.go
@@ -95,12 +95,12 @@ func main() {
 
 	var wg sync.WaitGroup
 	ssReading := true
-	var msgId uint64
+	var msgId uint64 = 0
 
 	// Parallel os ping and tcp stats handlers
 	wg.Add(2)
-	go getSocketStats(conn, &ssReading, tcpStats, &wg, &msgId)
 	go customPing(pingIp, &wg, donePing, osRtt)
+	go getSocketStats(conn, &ssReading, tcpStats, &wg, &msgId)
 
 	// Start making requests
 	requestSender(conn, interrupt, &ssReading, reset, &msgId)

--- a/client/requestHandling.go
+++ b/client/requestHandling.go
@@ -12,27 +12,24 @@ func requestSender(
 	c *websocket.Conn,
 	interrupt chan os.Signal,
 	ssReading *bool,
-	ssHandling chan uint64,
-	reset chan *websocket.Conn) {
+	reset chan *websocket.Conn,
+	msgId *uint64) {
 	payload := randomString(*requestBytes - 62 /* offset to set the perfect desired message size */)
-	var id uint64
 	// If *reps == 0 then loop infinitely, otherwise loop *reps times
 	if *reps != 0 {
 		*reps += 1
 	}
-	for id = 1; id != *reps; id++ {
+	*ssReading = true
+	for *msgId = 1; *msgId != *reps; *msgId++ {
 		tmp := getTimestamp()
 		jsonMap := DataJSON{
-			Id:              id,
+			Id:              *msgId,
 			Payload:         payload,
 			ClientTimestamp: tmp,
 			ServerTimestamp: time.Time{},
 		}
 		marshal, _ := json.Marshal(jsonMap)
-		*ssReading = true
-		ssHandling <- id
 		err := c.WriteMessage(websocket.TextMessage, marshal)
-		*ssReading = false
 		for err != nil {
 			log.Printf("Trying to reset connection...")
 			c = connect()
@@ -46,7 +43,7 @@ func requestSender(
 		tsDiff := (time.Duration(*interval) * time.Millisecond) - time.Duration(getTimestamp().Sub(tmp).Nanoseconds())
 		if tsDiff < 0 {
 			tsDiff = 0
-			log.Println("Warning: It was not possible to send message", id+1, "after the desired interval!")
+			log.Println("Warning: It was not possible to send message", *msgId+1, "after the desired interval!")
 		}
 		select {
 		case <-interrupt:
@@ -61,6 +58,7 @@ func requestSender(
 		case <-time.After(tsDiff):
 		}
 	}
+	*ssReading = false
 	err := c.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 	if err != nil {
 		log.Println("write close: ", err)

--- a/client/requestHandling.go
+++ b/client/requestHandling.go
@@ -19,7 +19,6 @@ func requestSender(
 	if *reps != 0 {
 		*reps += 1
 	}
-	*ssReading = true
 	for *msgId = 1; *msgId != *reps; *msgId++ {
 		tmp := getTimestamp()
 		jsonMap := DataJSON{
@@ -48,7 +47,6 @@ func requestSender(
 		select {
 		case <-interrupt:
 			log.Println("interrupt")
-
 			err := c.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 			if err != nil {
 				log.Println("write close: ", err)

--- a/client/requestHandling.go
+++ b/client/requestHandling.go
@@ -33,7 +33,9 @@ func requestSender(
 			log.Printf("Trying to reset connection...")
 			c = connect()
 			reset <- c
-			reset <- c
+			if *sockOpt {
+				reset <- c
+			}
 			jsonMap.Id = 0
 			jsonMap.Payload = "Connection Reset"
 			resetMarshal, _ := json.Marshal(jsonMap)
@@ -47,6 +49,7 @@ func requestSender(
 		select {
 		case <-interrupt:
 			log.Println("interrupt")
+			*ssReading = false
 			err := c.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 			if err != nil {
 				log.Println("write close: ", err)

--- a/client/responseHandling.go
+++ b/client/responseHandling.go
@@ -64,7 +64,8 @@ func singleRead(
 		toolRtt.WriteString(",")
 		toolRtt.WriteString(strconv.FormatInt(jsonMap.ServerTimestamp.UnixNano(), 10))
 		toolRtt.WriteString(",")
-		toolRtt.WriteString(strconv.FormatInt(latency.Milliseconds(), 10) + "." + strconv.Itoa(int(latency%time.Millisecond)))
+		toolRtt.WriteString(strconv.FormatInt(latency.Milliseconds(), 10) + "." +
+			strconv.Itoa(int(latency%time.Millisecond)))
 		toolRtt.WriteString("\n")
 	}
 }

--- a/client/systemUtils.go
+++ b/client/systemUtils.go
@@ -52,15 +52,18 @@ func getSocketStats(
 	tcpConn := getTCPConnFromWebsocketConn(conn)
 	var sockOpt []TimedTCPInfo
 	for *ssReading {
-		tcpInfo, _ := tcpinfo.GetsockoptTCPInfo(tcpConn)
-		sockOpt = append(sockOpt, TimedTCPInfo{
-			MsgId:     *msgId,
-			Timestamp: getTimestamp(),
-			TcpInfo:   tcpInfo,
-		})
+		if *msgId != 0 {
+			tcpInfo, _ := tcpinfo.GetsockoptTCPInfo(tcpConn)
+			sockOpt = append(sockOpt, TimedTCPInfo{
+				MsgId:     *msgId,
+				Timestamp: getTimestamp(),
+				TcpInfo:   tcpInfo,
+			})
+		}
 	}
 	for i, info := range sockOpt {
-		if i == 0 || !cmp.Equal(sockOpt[i].MsgId, sockOpt[i-1].MsgId) || !cmp.Equal(sockOpt[i].TcpInfo, sockOpt[i-1].TcpInfo) {
+		if i == 0 || !cmp.Equal(sockOpt[i].MsgId, sockOpt[i-1].MsgId) ||
+			!cmp.Equal(sockOpt[i].TcpInfo, sockOpt[i-1].TcpInfo) {
 			str := fmt.Sprintf("%v", *info.TcpInfo)
 			str = strings.ReplaceAll(str[1:len(str)-1], " ", ",")
 			str = strings.ReplaceAll(str, "[", "")

--- a/client/utility.go
+++ b/client/utility.go
@@ -77,6 +77,7 @@ func printLogs() {
 	log.Println("Send Interval:\t\t", *interval)
 	log.Println("TLS enabled:\t\t", *https)
 	log.Println("Traceroute enabled:\t", *traceroute)
+	log.Println("TCP Stats enabled:\t", *sockOpt)
 	log.Println("Address:\t\t", address)
 	log.Println("Ping and Traceroute IP:\t", pingIp)
 	log.Println()

--- a/client/utility.go
+++ b/client/utility.go
@@ -22,6 +22,7 @@ type DataJSON struct {
 }
 
 type TimedTCPInfo struct {
+	MsgId     uint64
 	Timestamp time.Time
 	TcpInfo   *tcpinfo.TCPInfo
 }


### PR DESCRIPTION
Since the non-continuous tcp stats retrieval returns useless info, with this PR it is continuous and requires to be explicitly requested with the `-tcpStats=true` flag. It is strongly suggested to use it for reduced execution time since it takes a lot of CPU and RAM.